### PR TITLE
Compatibility w/ Gradle 5.0 #18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,6 @@ pluginBundle {
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.3'
-}
-
 test {
     testLogging {
         events "failed"


### PR DESCRIPTION
Removed deprecated wrapper task from the build script.
 Compatibility w/ Gradle 5.0 #18 